### PR TITLE
Enhance Perm Buddy with searchable multi-select and unified export

### DIFF
--- a/searchableMultiSelect.css
+++ b/searchableMultiSelect.css
@@ -1,0 +1,47 @@
+.multi-select {
+    position: relative;
+    margin-bottom: 1rem;
+}
+.search {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #dadce0;
+    border-radius: 4px;
+}
+.options {
+    position: absolute;
+    z-index: 2;
+    background: #fff;
+    border: 1px solid #dadce0;
+    width: 100%;
+    max-height: 10rem;
+    overflow-y: auto;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+.options li {
+    padding: 0.5rem;
+    cursor: pointer;
+}
+.options li:hover {
+    background: #f1f3f4;
+}
+.selected {
+    margin-top: 0.5rem;
+}
+.pill {
+    display: inline-flex;
+    align-items: center;
+    background: #e8eaed;
+    border-radius: 16px;
+    padding: 0 0.5rem;
+    margin: 0.25rem;
+    font-size: 0.75rem;
+}
+.remove {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding-left: 0.25rem;
+}

--- a/searchableMultiSelect.html
+++ b/searchableMultiSelect.html
@@ -1,0 +1,18 @@
+<template>
+  <div class="multi-select">
+    <label class="slds-form-element__label">{label}</label>
+    <input type="text" class="search" placeholder="Search..." value={searchTerm} oninput={handleSearch} />
+    <ul class="options" if:true={filteredOptions.length}>
+      <template for:each={filteredOptions} for:item="opt">
+        <li key={opt.value} data-value={opt.value} onclick={selectOption}> {opt.label} </li>
+      </template>
+    </ul>
+    <div class="selected" if:true={selectedValues.length}>
+      <template for:each={selectedValues} for:item="val">
+        <span key={val} class="pill">{getLabel(val)}
+          <button type="button" data-value={val} class="remove" onclick={removeSelection}>×</button>
+        </span>
+      </template>
+    </div>
+  </div>
+</template>

--- a/searchableMultiSelect.js
+++ b/searchableMultiSelect.js
@@ -1,0 +1,47 @@
+import { LightningElement, api, track } from 'lwc';
+
+// Simple chip-based multi-select with search filtering
+export default class SearchableMultiSelect extends LightningElement {
+    @api label = '';
+    @api options = [];
+
+    @track selectedValues = [];
+    @track searchTerm = '';
+
+    get filteredOptions() {
+        if (!this.searchTerm) {
+            return [];
+        }
+        const term = this.searchTerm.toLowerCase();
+        return this.options
+            .filter(opt => opt.label.toLowerCase().includes(term) && !this.selectedValues.includes(opt.value));
+    }
+
+    getLabel(val) {
+        const opt = this.options.find(o => o.value === val);
+        return opt ? opt.label : val;
+    }
+
+    handleSearch(event) {
+        this.searchTerm = event.target.value;
+    }
+
+    selectOption(event) {
+        const value = event.currentTarget.dataset.value;
+        if (!this.selectedValues.includes(value)) {
+            this.selectedValues = [...this.selectedValues, value];
+            this.dispatchChange();
+        }
+        this.searchTerm = '';
+    }
+
+    removeSelection(event) {
+        const value = event.currentTarget.dataset.value;
+        this.selectedValues = this.selectedValues.filter(v => v !== value);
+        this.dispatchChange();
+    }
+
+    dispatchChange() {
+        this.dispatchEvent(new CustomEvent('change', { detail: this.selectedValues }));
+    }
+}

--- a/wywPermBuddy.css
+++ b/wywPermBuddy.css
@@ -1,47 +1,40 @@
 .slds-p-around_medium {
-
-    background: #f9f9f9;
-
+    background: #fff;
     border-radius: 8px;
-
-    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-
+    box-shadow: 0 1px 3px rgba(60,64,67,0.15);
     margin-bottom: 16px;
-
 }
 
+.header {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+.header h1 {
+    font-weight: 400;
+    color: #202124;
+}
+.info {
+    margin-bottom: 1rem;
+    color: #5f6368;
+}
 .export-btn, .import-btn {
-
     min-width: 120px;
-
     font-weight: 600;
-
-    background: #0070d2;
-
+    background: #1a73e8;
     color: #fff;
-
     border-radius: 4px;
-
 }
-
 .export-btn:hover, .import-btn:hover {
-
-    background: #005fb2;
-
-    color: #fff;
-
+    background: #1558b0;
 }
-
 .import-file {
-
     margin-top: 12px;
-
     margin-bottom: 12px;
-
 }
-
-.lightning-dual-listbox {
-
-    margin-bottom: 16px;
-
+.support {
+    text-align: center;
+    margin-top: 1rem;
+}
+.support a {
+    color: #1a73e8;
 }

--- a/wywPermBuddy.html
+++ b/wywPermBuddy.html
@@ -1,151 +1,48 @@
 <template>
+    <div class="header">
+        <h1>Perm Buddy</h1>
+        <p>Please see sample CSV for Import/Export:
+            <a href={fieldSampleUrl} download>Field Sample</a> |
+            <a href={objectSampleUrl} download>Object Sample</a>
+        </p>
+    </div>
 
     <lightning-card title="Permission Buddy">
-
         <div class="slds-p-around_medium">
+            <p class="info">Use the options below to import or export object and field permissions. Only CSV files are supported.</p>
 
             <lightning-combobox
-
-                label="Mode"
-
+                label="Please select an option"
                 value={mode}
-
                 options={modeOptions}
-
                 onchange={handleModeChange}>
-
             </lightning-combobox>
-
- 
 
             <lightning-combobox
-
-                label="Target Type"
-
+                label="What do you want to do?"
                 value={targetType}
-
                 options={targetTypeOptions}
-
                 onchange={handleTargetTypeChange}>
-
             </lightning-combobox>
-
- 
 
             <template if:true={showExport}>
-
-                <lightning-combobox
-
-                    label="Persona Type"
-
-                    value={personaType}
-
-                    options={personaTypeOptions}
-
-                    onchange={handlePersonaTypeChange}>
-
-                </lightning-combobox>
-
- 
-
-                <lightning-dual-listbox
-
-                    label="Objects"
-
-                    source-label="Available"
-
-                    selected-label="Selected"
-
-                    options={objectOptions}
-
-                    value={selectedObjects}
-
-                    onchange={handleObjectChange}>
-
-                </lightning-dual-listbox>
-
- 
-
-                <template if:true={showProfileSelect}>
-
-                    <lightning-dual-listbox
-
-                        label="Profiles"
-
-                        source-label="Available"
-
-                        selected-label="Selected"
-
-                        options={profileOptions}
-
-                        value={selectedProfiles}
-
-                        onchange={handleProfileChange}>
-
-                    </lightning-dual-listbox>
-
-                </template>
-
-                <template if:true={showPermSetSelect}>
-
-                    <lightning-dual-listbox
-
-                        label="Permission Sets"
-
-                        source-label="Available"
-
-                        selected-label="Selected"
-
-                        options={permSetOptions}
-
-                        value={selectedPermSets}
-
-                        onchange={handlePermSetChange}>
-
-                    </lightning-dual-listbox>
-
-                </template>
-
- 
-
+                <c-searchable-multi-select label="Objects" options={objectOptions} onchange={handleObjectChange}></c-searchable-multi-select>
+                <c-searchable-multi-select label="Profiles" options={profileOptions} onchange={handleProfileChange}></c-searchable-multi-select>
+                <c-searchable-multi-select label="Permission Sets" options={permSetOptions} onchange={handlePermSetChange}></c-searchable-multi-select>
                 <template if:true={showFieldSelect}>
-
-                    <lightning-dual-listbox
-
-                        label="Fields"
-
-                        source-label="Available"
-
-                        selected-label="Selected"
-
-                        options={fieldOptions}
-
-                        value={selectedFields}
-
-                        onchange={handleFieldChange}>
-
-                    </lightning-dual-listbox>
-
+                    <c-searchable-multi-select label="Fields" options={fieldOptions} onchange={handleFieldChange}></c-searchable-multi-select>
                 </template>
-
- 
-
                 <lightning-button label="Export CSV" onclick={handleExport} class="slds-m-top_medium export-btn"></lightning-button>
-
             </template>
-
- 
 
             <template if:true={showImport}>
-
-                <lightning-input type="file" label="Import CSV" onchange={handleFileChange} class="import-file"></lightning-input>
-
+                <lightning-input type="file" label="Import CSV" accept=".csv" onchange={handleFileChange} class="import-file"></lightning-input>
                 <lightning-button label="Import" onclick={handleImport} class="slds-m-top_medium import-btn"></lightning-button>
-
             </template>
-
         </div>
-
     </lightning-card>
 
+    <div class="support">
+        <a href="mailto:raviswanath@outlook.com">Developer Support</a>
+    </div>
 </template>

--- a/wywPermBuddy.js
+++ b/wywPermBuddy.js
@@ -1,375 +1,181 @@
 import { LightningElement, track } from 'lwc';
 
 import getAllSObjectApiNames from '@salesforce/apex/wywPermBuddyController.getAllSObjectApiNames';
-
 import getAllProfileNames from '@salesforce/apex/wywPermBuddyController.getAllProfileNames';
-
 import getAllPermissionSetNames from '@salesforce/apex/wywPermBuddyController.getAllPermissionSetNames';
-
 import getFieldsForObjects from '@salesforce/apex/wywPermBuddyController.getFieldsForObjects';
-
 import exportPermissions from '@salesforce/apex/wywPermBuddyController.exportPermissions';
-
 import processCsv from '@salesforce/apex/wywPermBuddyController.processCsv';
-
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
-
- 
+import fieldSample from '@salesforce/resourceUrl/fieldSample';
+import objectSample from '@salesforce/resourceUrl/objectSample';
 
 export default class WywPermBuddy extends LightningElement {
-
     @track mode = 'Export';
-
     @track targetType = 'Object';
-
-    @track personaType = 'Profile';
-
     @track selectedObjects = [];
-
     @track selectedProfiles = [];
-
     @track selectedPermSets = [];
-
     @track selectedFields = [];
-
     @track objectOptions = [];
-
     @track profileOptions = [];
-
     @track permSetOptions = [];
-
     @track fieldOptions = [];
-
     @track fileContent = '';
-
     @track req = {};
 
- 
+    fieldSampleUrl = fieldSample;
+    objectSampleUrl = objectSample;
 
     modeOptions = [
-
         { label: 'Export', value: 'Export' },
-
         { label: 'Import', value: 'Import' }
-
     ];
-
- 
 
     targetTypeOptions = [
-
         { label: 'Object', value: 'Object' },
-
         { label: 'Field', value: 'Field' }
-
     ];
-
- 
-
-    personaTypeOptions = [
-
-        { label: 'Profile', value: 'Profile' },
-
-        { label: 'Permission Set', value: 'PermissionSet' }
-
-    ];
-
- 
 
     get showExport() {
-
         return this.mode === 'Export';
-
     }
-
     get showImport() {
-
         return this.mode === 'Import';
-
     }
-
-    get showProfileSelect() {
-
-        return this.personaType === 'Profile' && this.showExport;
-
-    }
-
-    get showPermSetSelect() {
-
-        return this.personaType === 'PermissionSet' && this.showExport;
-
-    }
-
     get showFieldSelect() {
-
         return this.targetType === 'Field' && this.showExport;
-
     }
-
- 
 
     connectedCallback() {
-
         this.loadObjects();
-
         this.loadProfiles();
-
         this.loadPermSets();
-
     }
 
- 
-
+    // Load metadata for selectors
     loadObjects() {
-
         getAllSObjectApiNames().then(data => {
-
             this.objectOptions = data.map(o => ({ label: o, value: o }));
-
         });
-
     }
-
     loadProfiles() {
-
         getAllProfileNames().then(data => {
-
             this.profileOptions = data.map(p => ({ label: p, value: p }));
-
         });
-
     }
-
     loadPermSets() {
-
         getAllPermissionSetNames().then(data => {
-
             this.permSetOptions = data.map(p => ({ label: p, value: p }));
-
         });
-
     }
-
     loadFields() {
-
         if (this.selectedObjects.length > 0) {
-
             getFieldsForObjects({ objectApiNames: this.selectedObjects }).then(data => {
-
                 this.fieldOptions = data.map(f => ({ label: f, value: f }));
-
             });
-
         } else {
-
             this.fieldOptions = [];
-
         }
-
     }
-
- 
 
     handleModeChange(event) {
-
         this.mode = event.detail.value;
-
     }
-
     handleTargetTypeChange(event) {
-
         this.targetType = event.detail.value;
-
         this.selectedFields = [];
-
         this.loadFields();
-
     }
-
-    handlePersonaTypeChange(event) {
-
-        this.personaType = event.detail.value;
-
-    }
-
     handleObjectChange(event) {
-
-        this.selectedObjects = event.detail.value;
-
+        this.selectedObjects = event.detail;
         this.loadFields();
-
     }
-
     handleProfileChange(event) {
-
-        this.selectedProfiles = event.detail.value;
-
+        this.selectedProfiles = event.detail;
     }
-
     handlePermSetChange(event) {
-
-        this.selectedPermSets = event.detail.value;
-
+        this.selectedPermSets = event.detail;
     }
-
     handleFieldChange(event) {
-
-        this.selectedFields = event.detail.value;
-
+        this.selectedFields = event.detail;
     }
 
- 
-
+    // Build request and trigger Apex export
     handleExport() {
-
         this.req = {
-
             exportType: this.targetType,
-
             objectApiNames: this.selectedObjects,
-
             profileNames: this.selectedProfiles,
-
             permSetNames: this.selectedPermSets,
-
-            fieldApiNames: this.selectedFields,
-
-            personaType: this.personaType
-
+            fieldApiNames: this.selectedFields
         };
-
         exportPermissions({ req: this.req })
-
             .then(csv => {
-
                 this.downloadCSV(csv, `permissions_${this.targetType.toLowerCase()}.csv`);
-
                 this.showToast('Export successful!', 'CSV file downloaded.', 'success');
-
             })
-
             .catch(err => {
-
                 this.showToast('Export failed', this.reduceError(err), 'error');
-
             });
-
     }
-
- 
 
     handleFileChange(event) {
-
         const file = event.target.files[0];
-
-        if (file) {
-
+        if (file && file.name.toLowerCase().endsWith('.csv')) {
             const reader = new FileReader();
-
-            reader.onload = () => {
-
-                this.fileContent = reader.result;
-
-            };
-
+            reader.onload = () => { this.fileContent = reader.result; };
             reader.readAsText(file);
-
+        } else {
+            this.fileContent = '';
+            this.showToast('Invalid file', 'Please upload a CSV file.', 'error');
         }
-
     }
-
- 
 
     handleImport() {
-
         if (!this.fileContent) {
-
             this.showToast('Import failed', 'Please select a CSV file to import.', 'error');
-
             return;
-
         }
-
         processCsv({
-
             mode: 'Import',
-
             targetType: this.targetType,
-
             csvContent: this.fileContent
-
         })
-
-        .then(() => {
-
-            this.showToast('Import successful!', 'Permissions updated.', 'success');
-
-        })
-
-        .catch(err => {
-
-            this.showToast('Import failed', this.reduceError(err), 'error');
-
-        });
-
+            .then(() => {
+                this.showToast('Import successful!', 'Permissions updated.', 'success');
+            })
+            .catch(err => {
+                this.showToast('Import failed', this.reduceError(err), 'error');
+            });
     }
-
- 
 
     downloadCSV(csv, filename) {
-
         const blob = new Blob([csv], { type: 'text/csv' });
-
         const link = document.createElement('a');
-
         link.href = URL.createObjectURL(blob);
-
         link.download = filename;
-
         link.click();
-
         URL.revokeObjectURL(link.href);
-
     }
-
- 
 
     reduceError(error) {
-
         if (Array.isArray(error.body)) {
-
             return error.body.map(e => e.message).join(', ');
-
         } else if (error.body && typeof error.body.message === 'string') {
-
             return error.body.message;
-
         }
-
         return error.message || JSON.stringify(error);
-
     }
-
- 
 
     showToast(title, message, variant) {
-
         this.dispatchEvent(
-
             new ShowToastEvent({
-
-                title: title,
-
-                message: message,
-
-                variant: variant,
-
+                title,
+                message,
+                variant,
                 mode: 'dismissable'
-
             })
-
         );
-
     }
-
 }

--- a/wywPermBuddyController.cls
+++ b/wywPermBuddyController.cls
@@ -14,7 +14,6 @@ public with sharing class wywPermBuddyController {
 
         @AuraEnabled public List<String> fieldApiNames; // For field export, format: Object.Field
 
-        @AuraEnabled public String personaType; // 'Profile' or 'PermissionSet'
 
     }
 
@@ -68,7 +67,7 @@ public with sharing class wywPermBuddyController {
 
         if (targetType == 'Field') {
 
-            String expected = 'Object API Name,Field API Name,Access (Read/Edit),Profile/PermissionSet,Persona Name';
+            String expected = 'Object API Name,Field API Name,Persona,Persona API Name,Access';
 
             if (header != expected) {
 
@@ -80,7 +79,7 @@ public with sharing class wywPermBuddyController {
 
         } else if (targetType == 'Object') {
 
-            String expected = 'Object API Name,Profile/Permission Set API Name,Read,Edit,Create,Delete,View All,Modify All';
+            String expected = 'Object API Name,Persona,Persona API Name,Read,Edit,Create,Delete,View All,Modify All';
 
             if (header != expected) {
 
@@ -124,9 +123,9 @@ public with sharing class wywPermBuddyController {
 
             if (cols.size() < 5) continue;
 
-            String personaKind = cols[3].trim();
+            String personaKind = cols[2].trim();
 
-            String personaApi = cols[4].trim();
+            String personaApi = cols[3].trim();
 
             if (personaKind == 'Profile') profileNames.add(personaApi);
 
@@ -172,11 +171,11 @@ public with sharing class wywPermBuddyController {
 
             String fieldApi = cols[1].trim();
 
-            String access = cols[2].trim();
+            String personaKind = cols[2].trim();
 
-            String personaKind = cols[3].trim();
+            String personaApi = cols[3].trim();
 
-            String personaApi = cols[4].trim();
+            String access = cols[4].trim();
 
  
 
@@ -306,23 +305,31 @@ public with sharing class wywPermBuddyController {
 
  
 
-        Set<String> parentApiNames = new Set<String>();
+        Set<String> profileNames = new Set<String>();
+
+        Set<String> permSetNames = new Set<String>();
 
         for (List<String> cols : rows) {
 
-            if (cols.size() < 8) continue;
+            if (cols.size() < 9) continue;
 
-            parentApiNames.add(cols[1].trim());
+            String personaKind = cols[1].trim();
+
+            String personaApi = cols[2].trim();
+
+            if (personaKind == 'Profile') profileNames.add(personaApi);
+
+            else if (personaKind == 'PermissionSet') permSetNames.add(personaApi);
 
         }
 
- 
+
 
         Map<String, Id> profileByName = new Map<String, Id>();
 
-        if (!parentApiNames.isEmpty()) {
+        if (!profileNames.isEmpty()) {
 
-            for (Profile p : [SELECT Id, Name FROM Profile WHERE Name IN :parentApiNames]) {
+            for (Profile p : [SELECT Id, Name FROM Profile WHERE Name IN :profileNames]) {
 
                 profileByName.put(p.Name, p.Id);
 
@@ -332,9 +339,9 @@ public with sharing class wywPermBuddyController {
 
         Map<String, Id> permSetByName = new Map<String, Id>();
 
-        if (!parentApiNames.isEmpty()) {
+        if (!permSetNames.isEmpty()) {
 
-            for (PermissionSet ps : [SELECT Id, Name FROM PermissionSet WHERE Name IN :parentApiNames]) {
+            for (PermissionSet ps : [SELECT Id, Name FROM PermissionSet WHERE Name IN :permSetNames]) {
 
                 permSetByName.put(ps.Name, ps.Id);
 
@@ -348,33 +355,39 @@ public with sharing class wywPermBuddyController {
 
         for (List<String> cols : rows) {
 
-            if (cols.size() < 8) continue;
+            if (cols.size() < 9) continue;
 
             String sObjectName = cols[0].trim();
 
-            String parentApi = cols[1].trim();
+            String personaKind = cols[1].trim();
 
-            Boolean canRead   = toBool(cols[2]);
+            String personaApi = cols[2].trim();
 
-            Boolean canEdit   = toBool(cols[3]);
+            Boolean canRead   = toBool(cols[3]);
 
-            Boolean canCreate = toBool(cols[4]);
+            Boolean canEdit   = toBool(cols[4]);
 
-            Boolean canDelete = toBool(cols[5]);
+            Boolean canCreate = toBool(cols[5]);
 
-            Boolean viewAll   = toBool(cols[6]);
+            Boolean canDelete = toBool(cols[6]);
 
-            Boolean modifyAll = toBool(cols[7]);
+            Boolean viewAll   = toBool(cols[7]);
 
- 
+            Boolean modifyAll = toBool(cols[8]);
 
-            Id parentId = profileByName.get(parentApi);
 
-            if (parentId == null) parentId = permSetByName.get(parentApi);
+
+            Id parentId;
+
+            if (personaKind == 'Profile') parentId = profileByName.get(personaApi);
+
+            else if (personaKind == 'PermissionSet') parentId = permSetByName.get(personaApi);
+
+            else continue;
 
             if (parentId == null) continue; // skip unknown parent
 
- 
+
 
             ObjectPermissions op = new ObjectPermissions();
 
@@ -573,206 +586,147 @@ public with sharing class wywPermBuddyController {
     @AuraEnabled
 
     public static String exportPermissions(ExportRequest req) {
-
         if (req == null || String.isBlank(req.exportType)) {
-
             throw new AuraHandledException('Export type is required.');
-
         }
-
         List<String> rows = new List<String>();
-
         Integer recordCount = 0;
-
         Integer recordLimit = 10000;
 
- 
-
         if (req.exportType == 'Object') {
-
-            rows.add('Object API Name,Profile/Permission Set,Persona API Name,Read,Edit,Create,Delete,View All,Modify All');
-
-            List<String> personaNames = req.personaType == 'Profile' ? req.profileNames : req.permSetNames;
-
-            if (personaNames == null || personaNames.isEmpty() || req.objectApiNames == null || req.objectApiNames.isEmpty()) {
-
+            rows.add('Object API Name,Persona,Persona API Name,Read,Edit,Create,Delete,View All,Modify All');
+            if (req.objectApiNames == null || req.objectApiNames.isEmpty() ||
+                ((req.profileNames == null || req.profileNames.isEmpty()) &&
+                 (req.permSetNames == null || req.permSetNames.isEmpty()))) {
                 throw new AuraHandledException('Please select at least one object and persona.');
-
             }
-
-            Map<String, Id> personaIdMap = new Map<String, Id>();
-
-            if (req.personaType == 'Profile') {
-
-                for (Profile p : [SELECT Id, Name FROM Profile WHERE Name IN :personaNames]) {
-
-                    personaIdMap.put(p.Name, p.Id);
-
+            // Collect profile ids by name
+            Map<String, Id> profileIdMap = new Map<String, Id>();
+            if (req.profileNames != null && !req.profileNames.isEmpty()) {
+                for (Profile p : [SELECT Id, Name FROM Profile WHERE Name IN :req.profileNames]) {
+                    profileIdMap.put(p.Name, p.Id);
                 }
-
-            } else {
-
-                for (PermissionSet ps : [SELECT Id, Name FROM PermissionSet WHERE Name IN :personaNames]) {
-
-                    personaIdMap.put(ps.Name, ps.Id);
-
-                }
-
             }
+            // Collect permission set ids by name
+            Map<String, Id> permSetIdMap = new Map<String, Id>();
+            if (req.permSetNames != null && !req.permSetNames.isEmpty()) {
+                for (PermissionSet ps : [SELECT Id, Name FROM PermissionSet WHERE Name IN :req.permSetNames]) {
+                    permSetIdMap.put(ps.Name, ps.Id);
+                }
+            }
+            Set<Id> personaIds = new Set<Id>();
+            personaIds.addAll(profileIdMap.values());
+            personaIds.addAll(permSetIdMap.values());
 
+            // Query object permissions for selected personas
             List<ObjectPermissions> perms = [
-
                 SELECT SObjectType, ParentId, PermissionsRead, PermissionsEdit, PermissionsCreate, PermissionsDelete, PermissionsViewAllRecords, PermissionsModifyAllRecords
-
                 FROM ObjectPermissions
-
-                WHERE SObjectType IN :req.objectApiNames AND ParentId IN :personaIdMap.values()
-
+                WHERE SObjectType IN :req.objectApiNames AND ParentId IN :personaIds
             ];
+            Map<Id, String> profileNameById = new Map<Id, String>();
+            for (String name : profileIdMap.keySet()) profileNameById.put(profileIdMap.get(name), name);
+            Map<Id, String> permSetNameById = new Map<Id, String>();
+            for (String name : permSetIdMap.keySet()) permSetNameById.put(permSetIdMap.get(name), name);
 
-            Map<Id, String> personaApiNameMap = new Map<Id, String>();
-
-            for (String key : personaIdMap.keySet()) {
-
-                personaApiNameMap.put(personaIdMap.get(key), key);
-
-            }
-
+            // Build CSV rows
             for (ObjectPermissions op : perms) {
-
                 if (++recordCount > recordLimit) throw new AuraHandledException('Export limit exceeded (10,000 records). Please reduce your selection.');
-
-                String personaApi = personaApiNameMap.get(op.ParentId);
-
-                String personaType = req.personaType == 'Profile' ? 'Profile' : 'PermissionSet';
-
+                String personaType;
+                String personaApi;
+                if (profileNameById.containsKey(op.ParentId)) {
+                    personaType = 'Profile';
+                    personaApi = profileNameById.get(op.ParentId);
+                } else {
+                    personaType = 'PermissionSet';
+                    personaApi = permSetNameById.get(op.ParentId);
+                }
                 rows.add(String.join(new List<String>{
-
                     op.SObjectType,
-
                     personaType,
-
                     personaApi,
-
                     op.PermissionsRead ? 'True' : 'False',
-
                     op.PermissionsEdit ? 'True' : 'False',
-
                     op.PermissionsCreate ? 'True' : 'False',
-
                     op.PermissionsDelete ? 'True' : 'False',
-
                     op.PermissionsViewAllRecords ? 'True' : 'False',
-
                     op.PermissionsModifyAllRecords ? 'True' : 'False'
-
                 }, ','));
-
             }
-
         } else if (req.exportType == 'Field') {
-
-            rows.add('Object API Name,Field API Name,Access (Read/Edit),Profile/PermissionSet,Persona Name');
-
-            List<String> personaNames = req.personaType == 'Profile' ? req.profileNames : req.permSetNames;
-
-            if (personaNames == null || personaNames.isEmpty() || req.objectApiNames == null || req.objectApiNames.isEmpty() || req.fieldApiNames == null || req.fieldApiNames.isEmpty()) {
-
-                throw new AuraHandledException('Please select at least one object, persona, and field.');
-
+            rows.add('Object API Name,Field API Name,Persona,Persona API Name,Access');
+            if (req.objectApiNames == null || req.objectApiNames.isEmpty() ||
+                req.fieldApiNames == null || req.fieldApiNames.isEmpty() ||
+                ((req.profileNames == null || req.profileNames.isEmpty()) &&
+                 (req.permSetNames == null || req.permSetNames.isEmpty()))) {
+                throw new AuraHandledException('Please select at least one object, field, and persona.');
             }
-
-            Map<String, Id> personaIdMap = new Map<String, Id>();
-
-            if (req.personaType == 'Profile') {
-
-                for (Profile p : [SELECT Id, Name FROM Profile WHERE Name IN :personaNames]) {
-
-                    personaIdMap.put(p.Name, p.Id);
-
+            // Collect profile ids by name
+            Map<String, Id> profileIdMap = new Map<String, Id>();
+            if (req.profileNames != null && !req.profileNames.isEmpty()) {
+                for (Profile p : [SELECT Id, Name FROM Profile WHERE Name IN :req.profileNames]) {
+                    profileIdMap.put(p.Name, p.Id);
                 }
-
-            } else {
-
-                for (PermissionSet ps : [SELECT Id, Name FROM PermissionSet WHERE Name IN :personaNames]) {
-
-                    personaIdMap.put(ps.Name, ps.Id);
-
-                }
-
             }
+            // Collect permission set ids by name
+            Map<String, Id> permSetIdMap = new Map<String, Id>();
+            if (req.permSetNames != null && !req.permSetNames.isEmpty()) {
+                for (PermissionSet ps : [SELECT Id, Name FROM PermissionSet WHERE Name IN :req.permSetNames]) {
+                    permSetIdMap.put(ps.Name, ps.Id);
+                }
+            }
+            Set<Id> personaIds = new Set<Id>();
+            personaIds.addAll(profileIdMap.values());
+            personaIds.addAll(permSetIdMap.values());
 
             Set<String> fieldKeys = new Set<String>(req.fieldApiNames);
-
+            // Query field permissions for selected personas
             List<FieldPermissions> perms = [
-
                 SELECT SObjectType, Field, ParentId, PermissionsRead, PermissionsEdit
-
                 FROM FieldPermissions
-
-                WHERE ParentId IN :personaIdMap.values()
-
+                WHERE ParentId IN :personaIds
             ];
+            Map<Id, String> profileNameById = new Map<Id, String>();
+            for (String name : profileIdMap.keySet()) profileNameById.put(profileIdMap.get(name), name);
+            Map<Id, String> permSetNameById = new Map<Id, String>();
+            for (String name : permSetIdMap.keySet()) permSetNameById.put(permSetIdMap.get(name), name);
 
-            Map<Id, String> personaApiNameMap = new Map<Id, String>();
-
-            for (String key : personaIdMap.keySet()) {
-
-                personaApiNameMap.put(personaIdMap.get(key), key);
-
-            }
-
+            // Build CSV rows
             for (FieldPermissions fp : perms) {
-
-                String[] fieldParts = fp.Field.split('\\.');
-
-                if (fieldParts.size() != 2) continue;
-
-                String objApi = fieldParts[0];
-
-                String fieldApi = fieldParts[1];
-
+                String[] parts = fp.Field.split('\\.');
+                if (parts.size() != 2) continue;
+                String objApi = parts[0];
+                String fieldApi = parts[1];
                 if (!req.objectApiNames.contains(objApi)) continue;
-
                 if (!fieldKeys.contains(fp.Field)) continue;
-
                 if (++recordCount > recordLimit) throw new AuraHandledException('Export limit exceeded (10,000 records). Please reduce your selection.');
-
-                String personaApi = personaApiNameMap.get(fp.ParentId);
-
-                String personaType = req.personaType == 'Profile' ? 'Profile' : 'PermissionSet';
-
-                if (fp.PermissionsRead) {
-
-                    rows.add(String.join(new List<String>{
-
-                        objApi,
-
-                        fieldApi,
-
-                        fp.PermissionsEdit ? 'Edit' : 'Read',
-
-                        personaType,
-
-                        personaApi
-
-                    }, ','));
-
+                String personaType;
+                String personaApi;
+                if (profileNameById.containsKey(fp.ParentId)) {
+                    personaType = 'Profile';
+                    personaApi = profileNameById.get(fp.ParentId);
+                } else {
+                    personaType = 'PermissionSet';
+                    personaApi = permSetNameById.get(fp.ParentId);
                 }
-
+                if (fp.PermissionsRead) {
+                    rows.add(String.join(new List<String>{
+                        objApi,
+                        fieldApi,
+                        personaType,
+                        personaApi,
+                        fp.PermissionsEdit ? 'Edit' : 'Read'
+                    }, ','));
+                }
             }
-
         } else {
-
             throw new AuraHandledException('Invalid export type.');
-
         }
-
+        if (recordCount == 0) {
+            throw new AuraHandledException('No permissions found for specified criteria.');
+        }
         return String.join(rows, '\n');
-
     }
-
- 
 
     // ----------- Helper Methods -----------
 


### PR DESCRIPTION
## Summary
- Introduce chip-based searchable multi-selects for objects, profiles, permission sets and fields
- Combine profile and permission set permissions into a single export CSV with clearer validation
- Refresh styling for a cleaner, Google-like look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aab75a30488323868c38ca091f7686